### PR TITLE
Fix up kustomize download instructions

### DIFF
--- a/docs/prerequisites/README.md
+++ b/docs/prerequisites/README.md
@@ -86,6 +86,7 @@ Install kustomize for Linux:
 ```sh
 curl --silent --location --remote-name \
 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.2.3/kustomize_kustomize.v3.2.3_linux_amd64" && \
+chmod a+x kustomize_kustomize.v3.2.3_linux_amd64 && \
 sudo mv kustomize_kustomize.v3.2.3_linux_amd64 /usr/local/bin/kustomize
 ```
 

--- a/docs/prerequisites/README.md
+++ b/docs/prerequisites/README.md
@@ -84,7 +84,7 @@ choco install kustomize
 Install kustomize for Linux:
 
 ```sh
-curl --silent --location \
+curl --silent --location --remote-name \
 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.2.3/kustomize_kustomize.v3.2.3_linux_amd64" && \
 sudo mv kustomize_kustomize.v3.2.3_linux_amd64 /usr/local/bin/kustomize
 ```


### PR DESCRIPTION
I had to use --remote-name or curl (7.65.3, Ubuntu) got confused about which name to use for the kustomize binary (after a couple of redirects).

I had to fix up file permissions (+x) as well.