### PR TITLE
Switch to SSH remote

### DIFF
--- a/docs/profile/README.md
+++ b/docs/profile/README.md
@@ -60,7 +60,7 @@ We'll use these variables to clone your repo and setup GitOps for your cluster.
 export GH_USER=YOUR_GITHUB_USERNAME
 export GH_REPO=appmesh-dev
 
-git clone https://github.com/${GH_USER}/${GH_REPO}
+git clone git@github.com:${GH_USER}/${GH_REPO}
 cd ${GH_REPO}
 ```
 


### PR DESCRIPTION
From zoom
```
In that section, you mention: `git clone https://git/hub.com/${GH_USER}/${GH_REPO}` which clone via an HTTP URL , but then `eksctl enable repo` uses —git-url with an SSH URL. You need to enable SSH access to your git repo, otherwise you get an error like this: 
[ℹ] Generating manifests
[ℹ] Cloning git@github.com:rodrigc/appmesh-dev
Cloning into '/var/folders/m0/xq5mbjy11b175l99w_1d_5ww0000gn/T/eksctl-install-flux-clone-388779752'...
The authenticity of host 'github.com (192.30.255.112)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com,192.30.255.112' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository. 
```

```
Also, it looks like `eksctl enable repo` does not accept https URLs, you get this error: Error: please supply a valid --git-url argument: got a HTTP(S) Git URL, but eksctl currently only supports SSH Git URLs . So you need to use an SSH URL, and you need to have SSH access to your GitHub repo working properly 
```